### PR TITLE
Fix for setting level 2 categories

### DIFF
--- a/src/main/java/com/ebay/feed/cli/FeedCli.java
+++ b/src/main/java/com/ebay/feed/cli/FeedCli.java
@@ -217,7 +217,7 @@ public class FeedCli {
 
     if (cmd.hasOption("c2f"))
       filterRequest.setLevelTwoCategories(new HashSet<String>(Arrays.asList(cmd
-          .getOptionValues("c3f"))));
+          .getOptionValues("c2f"))));
 
     if (cmd.hasOption("sellerf"))
       filterRequest.setSellerNames(new HashSet<String>(


### PR DESCRIPTION
Using command line, the level 2 categories filter was not being set correctly.
Fixing the typo so that level 2 categories are read from command line and set to the appropriate list.